### PR TITLE
Adapt to ortfomk's new layout system

### DIFF
--- a/src/:language/:work.pug
+++ b/src/:language/:work.pug
@@ -123,10 +123,6 @@ block content
 		}
 		{{ end }}
 
-		.contents {
-			grid-template-areas: {{ .CurrentWork.CSSGridTemplateAreas }};
-		}
-
 	script(src=(asset "vendor/dialog-polyfill.js"))
 	script.
 		document.querySelectorAll('dialog').forEach(el => {

--- a/src/:language/:work.pug
+++ b/src/:language/:work.pug
@@ -14,12 +14,10 @@ block content
 
 	h1(data-style=.CurrentWork.Metadata.Title)=.CurrentWork.Title
 
-	section.contents(style="display:grid")
+	section.contents
 
 		each _ in .CurrentWork.LayedOut
 			div.element(style=.CSS data-element-type=.Type)
-				if eq .Type "spacer"
-					.spacer
 				if eq .Type "paragraph"
 					!= .Content
 				if eq .Type "link"

--- a/src/:language/:work.pug
+++ b/src/:language/:work.pug
@@ -123,8 +123,7 @@ block content
 		{{ end }}
 
 		.contents {
-			grid-template-areas: 'h1'
-				{{ .CurrentWork.CSSGridTemplateAreas | tnindent 4 }}
+			grid-template-areas: {{ .CurrentWork.CSSGridTemplateAreas }};
 		}
 
 	script(src=(asset "vendor/dialog-polyfill.js"))

--- a/src/:language/:work.pug
+++ b/src/:language/:work.pug
@@ -13,62 +13,61 @@ block content
 		a.work-in-progress(i18n href="/#wip") work in progress
 
 	section.contents
-		h1(data-style=.CurrentWork.Metadata.Title)=.CurrentWork.Title
+		h1(data-style=.CurrentWork.Metadata.Title style="grid-area: h1")=.CurrentWork.Title
 
 		each _ in .CurrentWork.LayedOut
-			.row(data-columns=(len .))
-				each _ in .
-					if eq .Type "spacer"
-						.spacer
-					if eq .Type "paragraph"
-						!= .Content
-					if eq .Type "link"
-						a(href=.URL, id=.ID, title=.Title)=.Name
-					if eq .Type "media"
-						figure(data-content-type=.ContentType)
-							if eq .GeneralContentType "pdf"
-								.pdf-frame-container
-									iframe.pdf-frame(
+			each _ in .
+				if ne .Type "."
+					.cell(style="grid-area: {{ .GridArea }}")
+						if eq .Type "p"
+							!= .Content
+						if eq .Type "l"
+							a(href=.URL, id=.ID, title=.Title)=.Name
+						if eq .Type "m"
+							figure(data-content-type=.ContentType)
+								if eq .GeneralContentType "pdf"
+									.pdf-frame-container
+										iframe.pdf-frame(
+											src=(media .Path)
+											id=.ID
+											title=.Title
+											width="100%"
+											height="100%"
+										)=.Alt
+								
+								else if eq .GeneralContentType "audio"
+									audio(
 										src=(media .Path)
 										id=.ID
 										title=.Title
-										width="100%"
-										height="100%"
 									)=.Alt
-							
-							else if eq .GeneralContentType "audio"
-								audio(
-									src=(media .Path)
-									id=.ID
-									title=.Title
-								)=.Alt
 
-							else if eq .GeneralContentType "image"
-								img(
-									data-full-src=(media .Path)
-									src=(.ThumbnailSource 400)
-									id=.ID
-									title=.Title
-									alt=.Alt
-									intrinsicsize="{{ .Dimensions.Width }}x{{ .Dimensions.Height }}"
-									data-aspect-ratio=.Dimensions.AspectRatio
-								)
+								else if eq .GeneralContentType "image"
+									img(
+										data-full-src=(media .Path)
+										src=(.ThumbnailSource 400)
+										id=.ID
+										title=.Title
+										alt=.Alt
+										intrinsicsize="{{ .Dimensions.Width }}x{{ .Dimensions.Height }}"
+										data-aspect-ratio=.Dimensions.AspectRatio
+									)
 
-							else if eq .GeneralContentType "video"
-								video(
-									src=(media .Path)
-									id=.ID
-									title=.Title
-								)=.Alt
-							
-							else
-								a(
-									src=(media .Path)
-									id=.ID
-								)=(or .Title .Alt)
+								else if eq .GeneralContentType "video"
+									video(
+										src=(media .Path)
+										id=.ID
+										title=.Title
+									)=.Alt
+								
+								else
+									a(
+										src=(media .Path)
+										id=.ID
+									)=(or .Title .Alt)
 
-							if .Title
-								figcaption=.Title
+								if .Title
+									figcaption=.Title
 
 	if len .CurrentWork.Footnotes
 		section.footnotes
@@ -122,6 +121,11 @@ block content
 			background-image: url('{{ media (printf "%s/%s" .CurrentWork.ID .CurrentWork.Metadata.PageBackground) }}');
 		}
 		{{ end }}
+
+		.contents {
+			grid-template-areas: 'h1'
+				{{ .CurrentWork.CSSGridTemplateAreas | tnindent 4 }}
+		}
 
 	script(src=(asset "vendor/dialog-polyfill.js"))
 	script.

--- a/src/:language/:work.pug
+++ b/src/:language/:work.pug
@@ -12,62 +12,63 @@ block content
 	if .CurrentWork.IsWIP
 		a.work-in-progress(i18n href="/#wip") work in progress
 
-	section.contents
-		h1(data-style=.CurrentWork.Metadata.Title style="grid-area: h1")=.CurrentWork.Title
+	h1(data-style=.CurrentWork.Metadata.Title)=.CurrentWork.Title
+
+	section.contents(style="display:grid")
 
 		each _ in .CurrentWork.LayedOut
-			each _ in .
-				if ne .Type "."
-					.cell(style="grid-area: {{ .GridArea }}")
-						if eq .Type "p"
-							!= .Content
-						if eq .Type "l"
-							a(href=.URL, id=.ID, title=.Title)=.Name
-						if eq .Type "m"
-							figure(data-content-type=.ContentType)
-								if eq .GeneralContentType "pdf"
-									.pdf-frame-container
-										iframe.pdf-frame(
-											src=(media .Path)
-											id=.ID
-											title=.Title
-											width="100%"
-											height="100%"
-										)=.Alt
-								
-								else if eq .GeneralContentType "audio"
-									audio(
-										src=(media .Path)
-										id=.ID
-										title=.Title
-									)=.Alt
+			div.element(style=.CSS data-element-type=.Type)
+				if eq .Type "spacer"
+					.spacer
+				if eq .Type "paragraph"
+					!= .Content
+				if eq .Type "link"
+					a(href=.URL, id=.ID, title=.Title)=.Name
+				if eq .Type "media"
+					figure(data-content-type=.ContentType)
+						if eq .GeneralContentType "pdf"
+							.pdf-frame-container
+								iframe.pdf-frame(
+									src=(media .Path)
+									id=.ID
+									title=.Title
+									width="100%"
+									height="100%"
+								)=.Alt
+						
+						else if eq .GeneralContentType "audio"
+							audio(
+								src=(media .Path)
+								id=.ID
+								title=.Title
+							)=.Alt
 
-								else if eq .GeneralContentType "image"
-									img(
-										data-full-src=(media .Path)
-										src=(.ThumbnailSource 400)
-										id=.ID
-										title=.Title
-										alt=.Alt
-										intrinsicsize="{{ .Dimensions.Width }}x{{ .Dimensions.Height }}"
-										data-aspect-ratio=.Dimensions.AspectRatio
-									)
+						else if eq .GeneralContentType "image"
+							img(
+								data-full-src=(media .Path)
+								src=(.ThumbnailSource 400)
+								id=.ID
+								title=.Title
+								alt=.Alt
+								intrinsicsize="{{ .Dimensions.Width }}x{{ .Dimensions.Height }}"
+								data-aspect-ratio=.Dimensions.AspectRatio
+							)
 
-								else if eq .GeneralContentType "video"
-									video(
-										src=(media .Path)
-										id=.ID
-										title=.Title
-									)=.Alt
-								
-								else
-									a(
-										src=(media .Path)
-										id=.ID
-									)=(or .Title .Alt)
+						else if eq .GeneralContentType "video"
+							video(
+								src=(media .Path)
+								id=.ID
+								title=.Title
+							)=.Alt
+						
+						else
+							a(
+								src=(media .Path)
+								id=.ID
+							)=(or .Title .Alt)
 
-								if .Title
-									figcaption=.Title
+						if .Title
+							figcaption=.Title
 
 	if len .CurrentWork.Footnotes
 		section.footnotes

--- a/src/style.styl
+++ b/src/style.styl
@@ -181,21 +181,21 @@ section.contents
 		justify-content center
 		margin 3rem 0.5rem
 
-	.row > a
+	.cell > a
 		shape-link()
 		justify-content center
 		align-self center
 
-	.row > p
+	.cell > p
 		font-size 1.15rem
 
 		.footnote-ref a
 			highlighter-link()
 
-	.row > figure
+	.cell > figure
 		overflow hidden
 
-	.row > figure > *
+	.cell > figure > *
 		width 100%
 		height 100%
 		object-fit contain

--- a/src/style.styl
+++ b/src/style.styl
@@ -176,9 +176,9 @@ section.contents
 	grid-auto-columns 1fr
 	gap 1em
 
-	.element[data-columns='1']
-		@media (min-width 1000px)
-			max-height 85vh
+	@media (max-width: 1000px)
+		display flex
+		flex-direction column
 
 	.element
 		display flex

--- a/src/style.styl
+++ b/src/style.styl
@@ -170,16 +170,11 @@ section.contents
 	margin 0 auto
 	padding 0 1rem
 	max-width 1000px
+	display grid
 
 	.row[data-columns='1']
 		@media (min-width 1000px)
 			max-height 85vh
-
-	.row
-		display flex
-		flex-direction row
-		justify-content center
-		margin 3rem 0.5rem
 
 	.cell > a
 		shape-link()
@@ -215,7 +210,6 @@ section.contents
 		opacity 0.5
 
 	&__list
-		// == layout
 		display flex
 		flex-wrap wrap
 		justify-content center

--- a/src/style.styl
+++ b/src/style.styl
@@ -171,26 +171,33 @@ section.contents
 	padding 0 1rem
 	max-width 1000px
 	display grid
+	grid-auto-columns 1fr
+	gap 1em
 
-	.row[data-columns='1']
+	.element[data-columns='1']
 		@media (min-width 1000px)
 			max-height 85vh
 
-	.cell > a
+	.element
+		display flex
+		flex-direction element
+		justify-content center
+
+	.element > a
 		shape-link()
 		justify-content center
 		align-self center
 
-	.cell > p
+	.element > p
 		font-size 1.15rem
 
 		.footnote-ref a
 			highlighter-link()
 
-	.cell > figure
+	.element > figure
 		overflow hidden
 
-	.cell > figure > *
+	.element > figure > *
 		width 100%
 		height 100%
 		object-fit contain


### PR DESCRIPTION
To be squashed when merged.
Do not merge until ortfo/mk#20 merges.

Todo:
- [x] Drop the `<.spacer>` generation, it shouldn't be needed.